### PR TITLE
サニタイズ処理を追加

### DIFF
--- a/System/Control/authControl.php
+++ b/System/Control/authControl.php
@@ -34,6 +34,7 @@ class authControl extends Smarty {
      * @param string $mode モード（'index' または 'register'）
      */
     public function execute($mode) {
+        $_POST = $this->common->sanitizeArray($_POST);
         $templateDir = 'Auth/';
         $errorMsg = null;
         $timeLimit = '0000-00-00 00:00:00';

--- a/System/Control/authControl.php
+++ b/System/Control/authControl.php
@@ -1,6 +1,7 @@
 <?php
 
 $rootPath = __DIR__ . '/..';
+global $postData; 
 
 require_once $rootPath . '/define.php';
 require_once $rootPath . CONTROL_PATH . '/commonControl.php';  // commonControl.phpをインクルード
@@ -34,7 +35,10 @@ class authControl extends Smarty {
      * @param string $mode モード（'index' または 'register'）
      */
     public function execute($mode) {
-        $_POST = $this->common->sanitizeArray($_POST);
+        if($_POST){
+            global $postData;
+            $postData = $this->common->sanitizeArray($_POST);
+        } 
         $templateDir = 'Auth/';
         $errorMsg = null;
         $timeLimit = '0000-00-00 00:00:00';
@@ -51,9 +55,9 @@ class authControl extends Smarty {
                 break;
             # ユーザ登録
             case 'register':
-                $name = $_POST['name'];
-                $email = $_POST['email'];
-                $password = $_POST['password'];
+                $name = $postData['name'];
+                $email = $postData['email'];
+                $password = $postData['password'];
                 # メールアドレスが登録済みか確認
                 if ($userModel->getUserByEmail($email)){
                     $errorMsg = '既に登録されたアドレスです';
@@ -75,8 +79,8 @@ class authControl extends Smarty {
                 break;
             # ログイン実行
             case 'login':
-                $email = $_POST['email'];
-                $password = $_POST['password'];
+                $email = $postData['email'];
+                $password = $postData['password'];
                 # パスワード認証
                 $isLogin = $this->verifyPassword($email, $password, $userModel);
                 if ($isLogin){
@@ -109,10 +113,10 @@ class authControl extends Smarty {
                 $templateDir .= 'showChangePassword.tpl';
                 break;
             case 'changePassword':
-                $email = $_POST['email'];
-                $currentPassword = $_POST['current_password'];
-                $newPassword = $_POST['new_password'];
-                $confirmNewPassword = $_POST['confirm_new_password'];
+                $email = $postData['email'];
+                $currentPassword = $postData['current_password'];
+                $newPassword = $postData['new_password'];
+                $confirmNewPassword = $postData['confirm_new_password'];
                 // パスワード更新を実行し、成否をメッセージ入れた元の画面に戻る。
                 $errorMsg = $this->executeChangePassword($email, $currentPassword, $newPassword, $confirmNewPassword);
                 $templateDir .= 'showChangePassword.tpl';
@@ -121,7 +125,7 @@ class authControl extends Smarty {
                 $templateDir .= 'showResetPassword.tpl';
                 break;
             case 'resetPassword':
-                $email = $_POST['email'];
+                $email = $postData['email'];
                 // アドレスでデータを取得
                 $user = $userModel->getUserByEmail($email);
                 // ユーザデータがない場合、処理終了
@@ -146,8 +150,8 @@ class authControl extends Smarty {
                 break;
             case 're-register':
                 $uuid = $_SESSION['reset_uuid'];
-                $newPassword = $_POST['new_password'];
-                $confirmNewPassword = $_POST['confirm_new_password'];
+                $newPassword = $postData['new_password'];
+                $confirmNewPassword = $postData['confirm_new_password'];
                 $errorMsg = 'パスワードの再設定に失敗しました';
                 # uuidからユーザデータを取得
                 $userData = $userModel->getUserDataByUuid($uuid);

--- a/System/Control/commonControl.php
+++ b/System/Control/commonControl.php
@@ -74,4 +74,30 @@ class CommonControl extends Smarty {
             }
         }
     }
+
+    /**
+     * 入力された文字のエスケープ処理を行います。
+     * 
+     * @param string $input 入力されたデータ
+     */
+    public function sanitizeInput($input) {
+        return htmlspecialchars($input, ENT_QUOTES, 'UTF-8');
+    }
+
+    /**
+     * 入力された配列データののエスケープ処理を行います。
+     * 
+     * @param array $array 配列データ
+     */
+    public function sanitizeArray($array) {
+        foreach ($array as $key => $value) {
+            # 多次元配列の場合は再度このメソッドを呼び出しエスケープ処理します。
+            if (is_array($value)) {
+                $array[$key] = $this->sanitizeArray($value);
+            } else {
+                $array[$key] = $this->sanitizeInput($value);
+            }
+        }
+        return $array;
+    }
 }

--- a/System/Control/mainControl.php
+++ b/System/Control/mainControl.php
@@ -35,7 +35,6 @@ class mainControl extends Smarty {
      * @param string $mode モード（'index' または 'register'）
      */
     public function execute($mode) {
-        $_POST = $this->common->sanitizeArray($_POST);
         $templateDir = 'Main/';
         $errorMsg = null;
         $this->ensureSessionStarted();

--- a/System/Control/mainControl.php
+++ b/System/Control/mainControl.php
@@ -35,6 +35,7 @@ class mainControl extends Smarty {
      * @param string $mode モード（'index' または 'register'）
      */
     public function execute($mode) {
+        $_POST = $this->common->sanitizeArray($_POST);
         $templateDir = 'Main/';
         $errorMsg = null;
         $this->ensureSessionStarted();

--- a/System/Control/userDetailControl.php
+++ b/System/Control/userDetailControl.php
@@ -1,6 +1,7 @@
 <?php
 
 $rootPath = __DIR__ . '/..';
+global $postData;
 
 require_once $rootPath . '/define.php';
 require_once $rootPath . CONTROL_PATH . '/commonControl.php';  // commonControl.phpをインクルード
@@ -36,7 +37,10 @@ class userDetailControl extends Smarty {
      * @param string $mode モード
      */
     public function execute($mode) {
-        $_POST = $this->common->sanitizeArray($_POST);
+        if ($_POST){
+            global $postData;
+            $postData = $this->common->sanitizeArray($_POST);
+        }
         $templateDir = 'UserDetail/';
         switch ($mode) {
             case 'privacy_policy_agreed':
@@ -106,16 +110,17 @@ class userDetailControl extends Smarty {
 
     /**POSTされた情報からユーザ詳細を更新*/
     public function updateUserDetail() {
-        $birthdate = $_POST['birthdate'];
-        $residence_prefecture = $_POST['residence_prefecture'];
-        $nick_name = $_POST['nick_name'];
-        $twitter_url = $_POST['twitter_url'];
-        $instagram_url = $_POST['instagram_url'];
-        $youtube_channel_url = $_POST['youtube_channel_url'];
-        $blog_url = $_POST['blog_url'];
+        global $postData;
+        $birthdate = $postData['birthdate'];
+        $residence_prefecture = $postData['residence_prefecture'];
+        $nick_name = $postData['nick_name'];
+        $twitter_url = $postData['twitter_url'];
+        $instagram_url = $postData['instagram_url'];
+        $youtube_channel_url = $postData['youtube_channel_url'];
+        $blog_url = $postData['blog_url'];
         $icon_url = $this->uploadImage('icon_url', 'Icon/');
         $profile_image_url = $this->uploadImage('profile_image_url', 'Profil/');
-        $self_introduction = $_POST['self_introduction'];
+        $self_introduction = $postData['self_introduction'];
         $_SESSION['completedToUserDetailRegistration'] = $this->userDetailModel->updateUserDetail(
             $birthdate, $residence_prefecture, $nick_name, $twitter_url, $instagram_url, $youtube_channel_url, $blog_url,
             $icon_url, $profile_image_url, $self_introduction, $_SESSION['user_id']

--- a/System/Control/userDetailControl.php
+++ b/System/Control/userDetailControl.php
@@ -36,6 +36,7 @@ class userDetailControl extends Smarty {
      * @param string $mode モード
      */
     public function execute($mode) {
+        $_POST = $this->common->sanitizeArray($_POST);
         $templateDir = 'UserDetail/';
         switch ($mode) {
             case 'privacy_policy_agreed':


### PR DESCRIPTION
サニタイズ処理を行うメソッドを追加し、各コントロールの最初でPOSTされた内容に
エスケープ処理を行う様にしました。

【理由】
XSS防止の為。
改修前はスクリプトを入力されるとDBへそのまま追加され、不正な処理を実行できる恐れがありました。
例）<script>window.location.href = 'https://github.com/sudoyuichi/campground_database/pull/34'; </script>
　　と入力してDBへ登録されると、以後そのページを見ると同時に上記サイトへリダイレクトされる。
　　<script>alert('You have been hacked!');</script>
　　アラートが表示される、など。